### PR TITLE
chore: bump version to 12.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Before you begin to integrate:
 
 ### API and SDK Version
 
-- SDK Version: 12.0.0
+- SDK Version: 12.0.1
 - API Version: 2026-07
 ## Quick Start
 
@@ -47,7 +47,7 @@ Before you begin to integrate:
 <dependency>
     <groupId>com.aftership</groupId>
     <artifactId>tracking-sdk</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.aftership</groupId>
     <artifactId>tracking-sdk</artifactId>
-    <version>12.0.0</version>
+    <version>12.0.1</version>
 
     <name>AfterShip Tracking SDK</name>
     <description>The official AfterShip Tracking Java API library</description>

--- a/src/main/java/com/aftership/tracking/http/HttpClient.java
+++ b/src/main/java/com/aftership/tracking/http/HttpClient.java
@@ -30,7 +30,7 @@ import org.apache.http.util.EntityUtils;
 public class HttpClient {
 
   private static final String DEFAULT_USER_AGENT =
-      "tracking-sdk-java/12.0.0 (https://www.aftership.com) apache-httpclient/4.5.14";
+      "tracking-sdk-java/12.0.1 (https://www.aftership.com) apache-httpclient/4.5.14";
   protected final org.apache.http.client.HttpClient client;
 
   public HttpClient(final RequestConfig requestConfig, String userAgent) {


### PR DESCRIPTION
## What

Version bump `12.0.0` → `12.0.1` for a dependency-only patch release, updated in all four places the version appears:

- `pom.xml` artifact version
- `README.md` (SDK Version line + maven dependency snippet)
- `HttpClient.java` user-agent string

## Why

#23 bumped `org.bouncycastle:bcprov-jdk18on` 1.78 → 1.84 (security update); publishing it to Maven Central requires a new release.

## Verification

- `mvn clean package` passes, produces `tracking-sdk-12.0.1.jar` (Java 8 target).
- BC 1.84 verified locally before #23 was merged: the only BC-dependent path (`Auth.getRsaSign`, `SHA256withRSA/PSS`) produces signatures that verify with the pure-JDK `RSASSA-PSS` verifier, identical behavior to 1.78; live read-only smoke (GetCouriers / GetTrackings) passed with the 1.84-built jar.

After merge: create release `12.0.1` (the `maven-publish.yml` workflow publishes on release creation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)